### PR TITLE
Added null/undefined check to prevent errors when loading a prendus quiz

### DIFF
--- a/redux-store.ts
+++ b/redux-store.ts
@@ -80,8 +80,11 @@ class ReduxStore {
             }
         };
 
-        stores[this.storeName].store.replaceReducer(augmentedReducer);
-        stores[this.storeName].store.dispatch(newValue);
+        if(stores[this.storeName]) {
+            stores[this.storeName].store.replaceReducer(augmentedReducer);
+            stores[this.storeName].store.dispatch(newValue);
+        }
+
     }
 
     rootReducerSet(newValue, oldValue) {


### PR DESCRIPTION
When not doing a null/undefined check, this error occurs when lazy-loading a quiz -
![image](https://cloud.githubusercontent.com/assets/10186520/21937655/63d794da-d975-11e6-893f-00402e8dc18e.png)

When doing a null/undefined check, this error never occurs and I can lazy-load a quiz!
![image](https://cloud.githubusercontent.com/assets/10186520/21937680/7f4a8038-d975-11e6-887c-8f4804fa0a50.png)
